### PR TITLE
Feature/add pace converter

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -50,6 +50,16 @@
   align-items: center;
 }
 
+.converter-container {
+  display: grid;
+  grid-template-rows: 1fr 1fr 1fr 1fr;
+  grid-template-columns: 1fr 2fr;
+  margin: 20px 0 20px 0;
+  font-size: 22px;
+  justify-items: left;
+  align-items: center;
+}
+
 input {
   width: 50px;
   height: 30px;
@@ -78,6 +88,13 @@ select {
   border-radius: 20px; /* Adjust the border-radius to make the container round */
 }
 
+.converter-box {
+  border: 2px solid black;
+  width: 500px;
+  height: 300px;
+  margin: 20px auto;
+  border-radius: 20px; /* Adjust the border-radius to make the container round */
+}
 
 .error {
   height: 20px;

--- a/src/App.css
+++ b/src/App.css
@@ -65,6 +65,11 @@ input {
   text-indent: 25px;
 }
 
+select {
+  width: 70px;
+  height: 30px;
+}
+
 .calculate-box {
   border: 2px solid black;
   width: 500px;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,7 +3,7 @@ import React from "react";
 import Logo from "./components/Logo";
 import Title from "./components/Title";
 import Form from "./components/Form";
-
+import Converter from "./components/Converter";
 
 function App() {
   
@@ -11,8 +11,10 @@ function App() {
     <div className="App">
       <Logo />
       <div className="App-main">
-        <Title />
+        <Title title={"Pace Calculator"} />
         <Form />
+        <Title title={"Pace Converter"} />
+        <Converter />
       </div>
     </div>
   );

--- a/src/components/Converter.jsx
+++ b/src/components/Converter.jsx
@@ -79,10 +79,11 @@ const Converter = () => {
   return (
     <div className="form">
       <form>
-        <div className="calculate-box container">
+        <div className="converter-box converter-container">
           <div className="label">
             <label>From:</label>
           </div>
+          <div className="input">
           <select
             value={formData.fromUnit}
             onChange={(e) => handleInputChange("fromUnit", e.target.value)}
@@ -91,10 +92,14 @@ const Converter = () => {
             <option value="kph">kph</option>
             <option value="mph">mph</option>
           </select>
+            
+
+          </div>
 
           <div className="label">
             <label>To:</label>
           </div>
+          <div className="input">
           <select
             value={formData.toUnit}
             onChange={(e) => handleInputChange("toUnit", e.target.value)}
@@ -105,11 +110,17 @@ const Converter = () => {
               </option>
             ))}
           </select>
-
+          </div>
           {formData.fromUnit === "minPerKm" ? (
+            <>
             <div className="label">
               <label>Pace:</label>
-              <div className="input">
+              </div>
+
+
+
+              <div className="inputboxes">
+                    <div className="input">
                 <input
                   type="number"
                   placeholder="min"
@@ -127,10 +138,16 @@ const Converter = () => {
                   value={formData.seconds}
                   onChange={(e) => handleInputChange("seconds", e.target.value)}
                 />
-              </div>
               &nbsp;/km&nbsp;
+              </div>
             </div>
+            <div className="label">
+            <label>Speed :</label>
+          </div>
+            </>
+            
           ) : (
+            <>
             <div className="label">
               <label>Speed:</label>
               <input 
@@ -141,9 +158,14 @@ const Converter = () => {
                 onChange={(e) => handleInputChange("speed", e.target.value)}
               />
             </div>
+             <div className="label">
+             <label>Pace:</label>
+             </div>
+             </>
           )}
+           
 
-          {result && <p className="result-text">{result}</p>}
+          {result && <p className="result-text input">{result}</p>}
         </div>
         <div className="error">{errorMessage}</div>
 

--- a/src/components/Converter.jsx
+++ b/src/components/Converter.jsx
@@ -2,6 +2,7 @@ import React, { useState } from "react";
 import Button from "./Button";
 
 const Converter = () => {
+  // Initial form values
   const initialFormData = {
     fromUnit: "minPerKm",
     toUnit: "kph",
@@ -15,6 +16,7 @@ const Converter = () => {
   const [result, setResult] = useState("");
   const [errorMessage, setErrorMessage] = useState("");
 
+  // Update form data on input change
   const handleInputChange = (name, value) => {
     setFormData((prevFormData) => ({
       ...prevFormData,
@@ -22,6 +24,7 @@ const Converter = () => {
     }));
   };
 
+  // Reset form state
   const resetForm = () => {
     setFormData(initialFormData);
     setResult("");
@@ -29,6 +32,7 @@ const Converter = () => {
     setIsConverted(false);
   };
 
+  // Handle conversion based on input type
   const handleConvert = () => {
     try {
       const { fromUnit, toUnit, minutes, seconds, speed } = formData;
@@ -37,19 +41,22 @@ const Converter = () => {
       if (fromUnit === "minPerKm") {
         const totalMinutes =
           parseFloat(minutes) + parseFloat(seconds || 0) / 60;
+
         if (isNaN(totalMinutes) || totalMinutes <= 0) {
           throw new Error("Invalid pace input. Please enter valid numbers.");
         }
+
         if (toUnit === "kph") {
           res = (60 / totalMinutes).toFixed(2) + " kph";
         } else if (toUnit === "mph") {
           res = ((60 / totalMinutes) * 0.621371).toFixed(2) + " mph";
         }
-      } else if (fromUnit === "kph" || fromUnit === "mph") {
+      } else {
         const spd = parseFloat(speed);
         if (isNaN(spd) || spd <= 0) {
           throw new Error("Invalid speed input. Please enter a valid number.");
         }
+
         const spdInKph = fromUnit === "mph" ? spd / 0.621371 : spd;
         const minutesPerKm = 60 / spdInKph;
         const mins = Math.floor(minutesPerKm);
@@ -65,110 +72,117 @@ const Converter = () => {
     }
   };
 
+  // Dropdown options for "To" unit
   const getToUnitOptions = () => {
     if (formData.fromUnit === "minPerKm") {
       return [
         { value: "kph", label: "kph" },
         { value: "mph", label: "mph" },
       ];
-    } else {
-      return [{ value: "minPerKm", label: "min/km" }];
     }
+    return [{ value: "minPerKm", label: "min/km" }];
   };
 
   return (
     <div className="form">
       <form>
         <div className="converter-box converter-container">
+          {/* From Unit */}
           <div className="label">
             <label>From:</label>
           </div>
           <div className="input">
-          <select
-            value={formData.fromUnit}
-            onChange={(e) => handleInputChange("fromUnit", e.target.value)}
-          >
-            <option value="minPerKm">min/km</option>
-            <option value="kph">kph</option>
-            <option value="mph">mph</option>
-          </select>
-            
-
+            <select
+              value={formData.fromUnit}
+              onChange={(e) => handleInputChange("fromUnit", e.target.value)}
+            >
+              <option value="minPerKm">min/km</option>
+              <option value="kph">kph</option>
+              <option value="mph">mph</option>
+            </select>
           </div>
 
+          {/* To Unit */}
           <div className="label">
             <label>To:</label>
           </div>
           <div className="input">
-          <select
-            value={formData.toUnit}
-            onChange={(e) => handleInputChange("toUnit", e.target.value)}
-          >
-            {getToUnitOptions().map((unit) => (
-              <option key={unit.value} value={unit.value}>
-                {unit.label}
-              </option>
-            ))}
-          </select>
+            <select
+              value={formData.toUnit}
+              onChange={(e) => handleInputChange("toUnit", e.target.value)}
+            >
+              {getToUnitOptions().map((unit) => (
+                <option key={unit.value} value={unit.value}>
+                  {unit.label}
+                </option>
+              ))}
+            </select>
           </div>
+
+          {/* Input fields */}
           {formData.fromUnit === "minPerKm" ? (
             <>
-            <div className="label">
-              <label>Pace:</label>
+              <div className="label">
+                <label>Pace:</label>
               </div>
-
-
-
               <div className="inputboxes">
-                    <div className="input">
-                <input
-                  type="number"
-                  placeholder="min"
-                  min={0}
-                  max={59}
-                  value={formData.minutes}
-                  onChange={(e) => handleInputChange("minutes", e.target.value)}
-                />
-                &nbsp;:&nbsp;
-                <input
-                  type="number"
-                  placeholder="sec"
-                  min={0}
-                  max={59}
-                  value={formData.seconds}
-                  onChange={(e) => handleInputChange("seconds", e.target.value)}
-                />
-              &nbsp;/km&nbsp;
+                <div className="input">
+                  <input
+                    type="number"
+                    placeholder="min"
+                    min={0}
+                    max={59}
+                    value={formData.minutes}
+                    onChange={(e) =>
+                      handleInputChange("minutes", e.target.value)
+                    }
+                  />
+                  <span>:</span>
+                  <input
+                    type="number"
+                    placeholder="sec"
+                    min={0}
+                    max={59}
+                    value={formData.seconds}
+                    onChange={(e) =>
+                      handleInputChange("seconds", e.target.value)
+                    }
+                  />
+                  <span> min/km</span>
+                </div>
               </div>
-            </div>
-            <div className="label">
-            <label>Speed :</label>
-          </div>
             </>
-            
           ) : (
             <>
-            <div className="label">
-              <label>Speed:</label>
-              <input 
-                className="input"
-                type="number"
-                placeholder={formData.fromUnit}
-                value={formData.speed}
-                onChange={(e) => handleInputChange("speed", e.target.value)}
-              />
-            </div>
-             <div className="label">
-             <label>Pace:</label>
-             </div>
-             </>
+              <div className="label">
+                <label>Speed:</label>
+              </div>
+              <div className="inputboxes">
+                <div className="input">
+                  <input
+                    type="number"
+                    placeholder={formData.fromUnit}
+                    value={formData.speed}
+                    onChange={(e) =>
+                      handleInputChange("speed", e.target.value)
+                    }
+                  />
+                  <span>
+                    {formData.fromUnit === "kph" ? " kph " : " mph "}
+                  </span>
+                </div>
+              </div>
+            </>
           )}
-           
 
+          {/* Result */}
           {result && <p className="result-text input">{result}</p>}
         </div>
+
+        {/* Error */}
         <div className="error">{errorMessage}</div>
 
+        {/* Button */}
         <Button
           onClick={isConverted ? resetForm : handleConvert}
           text={isConverted ? "Reset" : "Convert"}

--- a/src/components/Converter.jsx
+++ b/src/components/Converter.jsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 import Button from "./Button";
 
 const Converter = () => {
-  // Initial form values
+  // Initial form data state
   const initialFormData = {
     fromUnit: "minPerKm",
     toUnit: "kph",
@@ -11,12 +11,13 @@ const Converter = () => {
     speed: "",
   };
 
+  // State hooks for form values, result, error, and conversion state
   const [formData, setFormData] = useState(initialFormData);
   const [isConverted, setIsConverted] = useState(false);
   const [result, setResult] = useState("");
   const [errorMessage, setErrorMessage] = useState("");
 
-  // Update form data on input change
+  // Update a specific form field (e.g., minutes, seconds, speed, fromUnit, toUnit)
   const handleInputChange = (name, value) => {
     setFormData((prevFormData) => ({
       ...prevFormData,
@@ -24,7 +25,7 @@ const Converter = () => {
     }));
   };
 
-  // Reset form state
+  // Reset form and result state
   const resetForm = () => {
     setFormData(initialFormData);
     setResult("");
@@ -32,12 +33,13 @@ const Converter = () => {
     setIsConverted(false);
   };
 
-  // Handle conversion based on input type
+  // Handle conversion between pace (min/km) and speed (kph or mph)
   const handleConvert = () => {
     try {
       const { fromUnit, toUnit, minutes, seconds, speed } = formData;
       let res = "";
 
+      // Convert from pace (min/km) to speed
       if (fromUnit === "minPerKm") {
         const totalMinutes =
           parseFloat(minutes) + parseFloat(seconds || 0) / 60;
@@ -46,24 +48,30 @@ const Converter = () => {
           throw new Error("Invalid pace input. Please enter valid numbers.");
         }
 
+        // Convert to kph or mph
         if (toUnit === "kph") {
           res = (60 / totalMinutes).toFixed(2) + " kph";
         } else if (toUnit === "mph") {
           res = ((60 / totalMinutes) * 0.621371).toFixed(2) + " mph";
         }
+
       } else {
+        // Convert from speed (kph or mph) to pace
         const spd = parseFloat(speed);
         if (isNaN(spd) || spd <= 0) {
           throw new Error("Invalid speed input. Please enter a valid number.");
         }
 
+        // Convert mph to kph if necessary
         const spdInKph = fromUnit === "mph" ? spd / 0.621371 : spd;
         const minutesPerKm = 60 / spdInKph;
         const mins = Math.floor(minutesPerKm);
         const secs = Math.round((minutesPerKm - mins) * 60);
+
         res = `${mins}:${secs.toString().padStart(2, "0")} min/km`;
       }
 
+      // Set conversion result
       setResult(res);
       setErrorMessage("");
       setIsConverted(true);
@@ -72,7 +80,7 @@ const Converter = () => {
     }
   };
 
-  // Dropdown options for "To" unit
+  // Dynamically return options for the "To" unit dropdown based on "From" selection
   const getToUnitOptions = () => {
     if (formData.fromUnit === "minPerKm") {
       return [
@@ -87,14 +95,16 @@ const Converter = () => {
     <div className="form">
       <form>
         <div className="converter-box converter-container">
-          {/* From Unit */}
+          {/* From Unit Selection */}
           <div className="label">
             <label>From:</label>
           </div>
           <div className="input">
             <select
               value={formData.fromUnit}
-              onChange={(e) => handleInputChange("fromUnit", e.target.value)}
+              onChange={(e) =>
+                handleInputChange("fromUnit", e.target.value)
+              }
             >
               <option value="minPerKm">min/km</option>
               <option value="kph">kph</option>
@@ -102,14 +112,16 @@ const Converter = () => {
             </select>
           </div>
 
-          {/* To Unit */}
+          {/* To Unit Selection */}
           <div className="label">
             <label>To:</label>
           </div>
           <div className="input">
             <select
               value={formData.toUnit}
-              onChange={(e) => handleInputChange("toUnit", e.target.value)}
+              onChange={(e) =>
+                handleInputChange("toUnit", e.target.value)
+              }
             >
               {getToUnitOptions().map((unit) => (
                 <option key={unit.value} value={unit.value}>
@@ -119,7 +131,7 @@ const Converter = () => {
             </select>
           </div>
 
-          {/* Input fields */}
+          {/* Input fields for pace (minutes & seconds) */}
           {formData.fromUnit === "minPerKm" ? (
             <>
               <div className="label">
@@ -151,8 +163,13 @@ const Converter = () => {
                   <span> min/km</span>
                 </div>
               </div>
+
+              <div className="label">
+                <label>Speed :</label>
+              </div>
             </>
           ) : (
+            // Input field for speed
             <>
               <div className="label">
                 <label>Speed:</label>
@@ -172,17 +189,21 @@ const Converter = () => {
                   </span>
                 </div>
               </div>
+
+              <div className="label">
+                <label>Pace:</label>
+              </div>
             </>
           )}
 
-          {/* Result */}
+          {/* Display result */}
           {result && <p className="result-text input">{result}</p>}
         </div>
 
-        {/* Error */}
+        {/* Error message if input is invalid */}
         <div className="error">{errorMessage}</div>
 
-        {/* Button */}
+        {/* Convert or Reset button */}
         <Button
           onClick={isConverted ? resetForm : handleConvert}
           text={isConverted ? "Reset" : "Convert"}

--- a/src/components/Converter.jsx
+++ b/src/components/Converter.jsx
@@ -133,7 +133,7 @@ const Converter = () => {
           ) : (
             <div className="label">
               <label>Speed:</label>
-              <input
+              <input 
                 className="input"
                 type="number"
                 placeholder={formData.fromUnit}

--- a/src/components/Converter.jsx
+++ b/src/components/Converter.jsx
@@ -1,0 +1,159 @@
+import React, { useState } from "react";
+import Button from "./Button";
+
+const Converter = () => {
+  const initialFormData = {
+    fromUnit: "minPerKm",
+    toUnit: "kph",
+    minutes: "",
+    seconds: "",
+    speed: "",
+  };
+
+  const [formData, setFormData] = useState(initialFormData);
+  const [isConverted, setIsConverted] = useState(false);
+  const [result, setResult] = useState("");
+  const [errorMessage, setErrorMessage] = useState("");
+
+  const handleInputChange = (name, value) => {
+    setFormData((prevFormData) => ({
+      ...prevFormData,
+      [name]: value,
+    }));
+  };
+
+  const resetForm = () => {
+    setFormData(initialFormData);
+    setResult("");
+    setErrorMessage("");
+    setIsConverted(false);
+  };
+
+  const handleConvert = () => {
+    try {
+      const { fromUnit, toUnit, minutes, seconds, speed } = formData;
+      let res = "";
+
+      if (fromUnit === "minPerKm") {
+        const totalMinutes =
+          parseFloat(minutes) + parseFloat(seconds || 0) / 60;
+        if (isNaN(totalMinutes) || totalMinutes <= 0) {
+          throw new Error("Invalid pace input. Please enter valid numbers.");
+        }
+        if (toUnit === "kph") {
+          res = (60 / totalMinutes).toFixed(2) + " kph";
+        } else if (toUnit === "mph") {
+          res = ((60 / totalMinutes) * 0.621371).toFixed(2) + " mph";
+        }
+      } else if (fromUnit === "kph" || fromUnit === "mph") {
+        const spd = parseFloat(speed);
+        if (isNaN(spd) || spd <= 0) {
+          throw new Error("Invalid speed input. Please enter a valid number.");
+        }
+        const spdInKph = fromUnit === "mph" ? spd / 0.621371 : spd;
+        const minutesPerKm = 60 / spdInKph;
+        const mins = Math.floor(minutesPerKm);
+        const secs = Math.round((minutesPerKm - mins) * 60);
+        res = `${mins}:${secs.toString().padStart(2, "0")} min/km`;
+      }
+
+      setResult(res);
+      setErrorMessage("");
+      setIsConverted(true);
+    } catch (error) {
+      setErrorMessage(error.message);
+    }
+  };
+
+  const getToUnitOptions = () => {
+    if (formData.fromUnit === "minPerKm") {
+      return [
+        { value: "kph", label: "kph" },
+        { value: "mph", label: "mph" },
+      ];
+    } else {
+      return [{ value: "minPerKm", label: "min/km" }];
+    }
+  };
+
+  return (
+    <div className="form">
+      <form>
+        <div className="calculate-box container">
+          <div className="label">
+            <label>From:</label>
+          </div>
+          <select
+            value={formData.fromUnit}
+            onChange={(e) => handleInputChange("fromUnit", e.target.value)}
+          >
+            <option value="minPerKm">min/km</option>
+            <option value="kph">kph</option>
+            <option value="mph">mph</option>
+          </select>
+
+          <div className="label">
+            <label>To:</label>
+          </div>
+          <select
+            value={formData.toUnit}
+            onChange={(e) => handleInputChange("toUnit", e.target.value)}
+          >
+            {getToUnitOptions().map((unit) => (
+              <option key={unit.value} value={unit.value}>
+                {unit.label}
+              </option>
+            ))}
+          </select>
+
+          {formData.fromUnit === "minPerKm" ? (
+            <div className="label">
+              <label>Pace:</label>
+              <div className="input">
+                <input
+                  type="number"
+                  placeholder="min"
+                  min={0}
+                  max={59}
+                  value={formData.minutes}
+                  onChange={(e) => handleInputChange("minutes", e.target.value)}
+                />
+                &nbsp;:&nbsp;
+                <input
+                  type="number"
+                  placeholder="sec"
+                  min={0}
+                  max={59}
+                  value={formData.seconds}
+                  onChange={(e) => handleInputChange("seconds", e.target.value)}
+                />
+              </div>
+              &nbsp;/km&nbsp;
+            </div>
+          ) : (
+            <div className="label">
+              <label>Speed:</label>
+              <input
+                className="input"
+                type="number"
+                placeholder={formData.fromUnit}
+                value={formData.speed}
+                onChange={(e) => handleInputChange("speed", e.target.value)}
+              />
+            </div>
+          )}
+
+          {result && <p className="result-text">{result}</p>}
+        </div>
+        <div className="error">{errorMessage}</div>
+
+        <Button
+          onClick={isConverted ? resetForm : handleConvert}
+          text={isConverted ? "Reset" : "Convert"}
+        />
+      </form>
+    </div>
+  );
+};
+
+export default Converter;

--- a/src/components/Title.jsx
+++ b/src/components/Title.jsx
@@ -1,9 +1,9 @@
 import React from "react";
 
-function Title() {
+function Title({title}) {
   return (
     <div className="title">
-      <h1 className="title-text">Pace Calculator</h1>
+      <h1 className="title-text">{title}</h1>
     </div>
   );
 }


### PR DESCRIPTION
## ✨ Feature: Add speed-to-pace and pace-to-speed conversion logic

This PR introduces a new unit converter that allows users to convert between:
- Running pace (`min/km`) and speed (`kph` or `mph`)
- Speed (`kph` or `mph`) and running pace (`min/km`)

### Related Issue
Closes #3

---

### ✅ Changes

- Built a fully functional `Converter` React component
- Implemented dynamic form inputs based on selected unit:
  - For `min/km`: inputs for minutes and seconds
  - For `kph` or `mph`: single input for speed
- Added logic to handle conversion:
  - `min/km` → `kph` / `mph`
  - `kph` / `mph` → `min/km`
- Added state handling with `useState` for form data, results, and error handling
- Added error validation for user inputs (e.g., non-numeric, empty, or invalid values)
- Added a reset function to clear the form after conversion
- Dynamic dropdown options based on selected input unit
- Followed the existing UI components

---
### Screenshots (if applicable)
![image](https://github.com/user-attachments/assets/8d533083-cbc5-4723-bce7-f77d4afd0de1)


