### PR TITLE
Fix/UI break on mobile devices

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -177,6 +177,10 @@ select {
     bottom: 15px;
   }
 
+  .converter-input{
+    position:static;
+  }
+
  
   .calculate-box {
     width: 95%;

--- a/src/components/Converter.jsx
+++ b/src/components/Converter.jsx
@@ -99,7 +99,7 @@ const Converter = () => {
           <div className="label">
             <label>From :</label>
           </div>
-          <div className="input">
+          <div className="input converter-input">
             <select
               value={formData.fromUnit}
               onChange={(e) =>
@@ -116,7 +116,7 @@ const Converter = () => {
           <div className="label">
             <label>To :</label>
           </div>
-          <div className="input">
+          <div className="input converter-input">
             <select
               value={formData.toUnit}
               onChange={(e) =>
@@ -138,7 +138,7 @@ const Converter = () => {
                 <label>Pace :</label>
               </div>
               <div className="inputboxes">
-                <div className="input">
+                <div className="input converter-input">
                   <input
                     type="number"
                     placeholder="min"
@@ -175,7 +175,7 @@ const Converter = () => {
                 <label>Speed :</label>
               </div>
               <div className="inputboxes">
-                <div className="input">
+                <div className="input converter-input">
                   <input
                     type="number"
                     placeholder={formData.fromUnit}
@@ -197,7 +197,7 @@ const Converter = () => {
           )}
 
           {/* Display result */}
-          {result && <p className="result-text input">{result}</p>}
+          {result && <p className="result-text input converter-input">{result}</p>}
         </div>
 
         {/* Error message if input is invalid */}


### PR DESCRIPTION
## ✨ Fix: UI Break on Mobile Devices

This update resolves a UI issue on mobile devices to ensure the calculator layout renders correctly across screen sizes.

### Changes Made
- Added responsive CSS rules to match the existing calculator design.
- Ensured consistent layout for smaller screens.

### ✅ Tested On
- **iPhone SE** (`max-width: 480px`)
- **iPad Mini** (`min-width: 481px` and `max-width: 768px`)

### Related Issue
Closes #6

---
### Screenshots (if applicable)
**iPhone SE** (`max-width: 480px`)
![image](https://github.com/user-attachments/assets/074ece6d-f3db-454c-9ae6-cf15286df3d8)

**iPad Mini** (`min-width: 481px` and `max-width: 768px`)
![image](https://github.com/user-attachments/assets/3cd26f75-ef38-4924-85fa-896b1f9cba60)
